### PR TITLE
Display menu in landscape with fullscreen auto-scroll

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,6 +2,9 @@
 <html lang="nl">
 <head>
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
+    <meta name="screen-orientation" content="landscape">
+    <meta name="x5-orientation" content="landscape">
     <title>Menu - Nova Asia</title>
     <link rel="stylesheet" href="style.css">
 </head>

--- a/script.js
+++ b/script.js
@@ -1,5 +1,8 @@
 
 window.onload = function () {
+    if (document.documentElement.requestFullscreen) {
+        document.documentElement.requestFullscreen();
+    }
     setInterval(() => {
         window.scrollBy(0, 1);
         if (window.innerHeight + window.scrollY >= document.body.offsetHeight) {

--- a/style.css
+++ b/style.css
@@ -3,8 +3,18 @@ body {
     background-color: #fdf8f0;
     color: #3e3022;
     margin: 0;
-    padding: 40px 20px;
+    padding: 0;
     box-sizing: border-box;
+}
+
+@media screen and (orientation: portrait) {
+    body {
+        transform: rotate(90deg);
+        transform-origin: left top;
+        width: 100vh;
+        height: 100vw;
+        overflow: hidden;
+    }
 }
 
 body::-webkit-scrollbar {
@@ -31,49 +41,55 @@ h1 {
 }
 
 .menu-section {
-    max-width: 720px;
+    max-width: none;
     margin: 0 auto;
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+    gap: 20px;
+    width: 100%;
 }
 
 .menu-section h2 {
     font-size: 42px;
-    margin-bottom: 40px;
+    margin-bottom: 20px;
     color: #4c3520;
     border-bottom: 3px solid #d6bfa3;
     padding-bottom: 15px;
+    grid-column: 1 / -1;
 }
 
 .item {
     display: flex;
+    flex-direction: column;
     align-items: center;
-    margin-bottom: 40px;
-    padding-bottom: 25px;
-    border-bottom: 1px solid #dcd2c3;
+    margin: 0;
+    padding: 0;
+    border-bottom: none;
 }
 
 .item img {
-    width: 180px;       /* 图片更大 */
-    height: 180px;
+    width: 100%;
+    height: auto;
     object-fit: cover;
     border-radius: 14px;
-    margin-right: 30px;
+    margin: 0 0 10px;
     box-shadow: 0 3px 10px rgba(0, 0, 0, 0.15);
 }
 
 .info h3 {
-    font-size: 32px;   /* 菜名加大 */
+    font-size: 20px;
     margin: 0 0 10px;
     color: #2f1e12;
 }
 
 .info p {
-    font-size: 24px;   /* 描述加大 */
+    font-size: 16px;
     margin: 0 0 10px;
     color: #5e4730;
     line-height: 1.5;
 }
 
 .info strong {
-    font-size: 28px;   /* 价格加大 */
+    font-size: 18px;
     color: #a8733b;
 }


### PR DESCRIPTION
## Summary
- Orient menu for landscape usage with viewport and orientation meta tags.
- Display four dishes per row via grid layout and reduced font sizes.
- Request fullscreen on load and maintain automatic scrolling.

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68905a6225cc83338467091e6913d530