### PR TITLE
Add standalone menu for Google Business

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,5 @@
 # NovaAsia_USB_Menu_NL
-To menu digital
+
+This repository contains a digital menu for Nova Asia. The `google-menu.html` file provides
+an inline-styled version that can be uploaded to Google Business so visitors can view the menu
+without external scripts or stylesheets.

--- a/google-menu.html
+++ b/google-menu.html
@@ -1,0 +1,745 @@
+<!DOCTYPE html>
+<html lang="nl">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Menu - Nova Asia</title>
+    <style>
+        body {
+            font-family: "Segoe UI", Arial, sans-serif;
+            background-color: #fdf8f0;
+            color: #3e3022;
+            margin: 0;
+            padding: 0 5%;
+            box-sizing: border-box;
+        }
+
+        h1 {
+            text-align: center;
+            margin-bottom: 40px;
+        }
+
+        .menu-section {
+            margin-bottom: 40px;
+        }
+
+        .menu-section h2 {
+            border-bottom: 2px solid #d6bfa3;
+            padding-bottom: 10px;
+        }
+
+        .item {
+            display: flex;
+            align-items: center;
+            margin-bottom: 15px;
+        }
+
+        .item img {
+            width: 80px;
+            height: 80px;
+            object-fit: cover;
+            border-radius: 14px;
+            margin-right: 15px;
+        }
+
+        .info h3 {
+            margin: 0 0 5px;
+            font-size: 1.1em;
+            color: #2f1e12;
+        }
+
+        .info p {
+            margin: 0 0 5px;
+            color: #5e4730;
+        }
+
+        .info strong {
+            color: #a8733b;
+        }
+    </style>
+</head>
+<body>
+    <h1>Nova Asia - Digitale Menukaart</h1>
+    <div class="menu-section">
+        <h2>Bento box</h2>
+        <div class="item">
+            <img src="images/chicken-bento.jpg" alt="Japans Chicken Bento">
+            <div class="info">
+                <h3>Japans Chicken Bento</h3>
+                <p></p>
+                <strong>€ 22.00</strong>
+            </div>
+        </div>
+        <div class="item">
+            <img src="images/chicken-bento.jpg" alt="Korean Spicy Chicken Bento 🌶">
+            <div class="info">
+                <h3>Korean Spicy Chicken Bento 🌶</h3>
+                <p></p>
+                <strong>€ 22.00</strong>
+            </div>
+        </div>
+        <div class="item">
+            <img src="images/Meatlove bento.png" alt="Korean Beef Bento">
+            <div class="info">
+                <h3>Korean Beef Bento</h3>
+                <p></p>
+                <strong>€ 25.00</strong>
+            </div>
+        </div>
+        <div class="item">
+            <img src="images/Meatlove bento.png" alt="Meatlover Bento">
+            <div class="info">
+                <h3>Meatlover Bento</h3>
+                <p></p>
+                <strong>€ 25.00</strong>
+            </div>
+        </div>
+        <div class="item">
+            <img src="images/zalm-lover-bento.jpg" alt="Zalm Lover Bento">
+            <div class="info">
+                <h3>Zalm Lover Bento</h3>
+                <p></p>
+                <strong>€ 23.00</strong>
+            </div>
+        </div>
+        <div class="item">
+            <img src="images/ebi-lover-bento.png" alt="Ebi Lover Bento">
+            <div class="info">
+                <h3>Ebi Lover Bento</h3>
+                <p></p>
+                <strong>€ 23.00</strong>
+            </div>
+        </div>
+        <div class="item">
+            <img src="images/surf-turf-bento.jpg" alt="Surf &amp;amp; Turf Bento">
+            <div class="info">
+                <h3>Surf &amp;amp; Turf Bento</h3>
+                <p></p>
+                <strong>€ 25.00</strong>
+            </div>
+        </div>
+        <div class="item">
+            <img src="images/dimsum-bento.png" alt="Dimsum Bento">
+            <div class="info">
+                <h3>Dimsum Bento</h3>
+                <p></p>
+                <strong>€ 20.00</strong>
+            </div>
+        </div>
+        <div class="item">
+            <img src="images/lamskotelet-bento.jpg" alt="Lamskotelet(NZL) Bento">
+            <div class="info">
+                <h3>Lamskotelet(NZL) Bento</h3>
+                <p></p>
+                <strong>€ 30.00</strong>
+            </div>
+        </div>
+        <div class="item">
+            <img src="images/UNA.jpg" alt="Unagi Bento">
+            <div class="info">
+                <h3>Unagi Bento</h3>
+                <p></p>
+                <strong>€ 24.00</strong>
+            </div>
+        </div>
+        <div class="item">
+            <img src="images/tunapo.png" alt="Tuna Bento">
+            <div class="info">
+                <h3>Tuna Bento</h3>
+                <p></p>
+                <strong>€ 25.00</strong>
+            </div>
+        </div>
+        <div class="item">
+            <img src="images/veggie-bento.png" alt="Veggie Bento">
+            <div class="info">
+                <h3>Veggie Bento</h3>
+                <p></p>
+                <strong>€ 20.00</strong>
+            </div>
+        </div>
+        <div class="item">
+            <img src="images/SUSHI.jpg" alt="Bento Sushi Omakase">
+            <div class="info">
+                <h3>Bento Sushi Omakase</h3>
+                <p></p>
+                <strong>€ 24.00</strong>
+            </div>
+        </div>
+        <div class="item">
+            <img src="images/xbento.png" alt="">
+            <div class="info">
+                <h3></h3>
+                <p></p>
+                <strong></strong>
+            </div>
+        </div>
+    </div>
+    <div class="menu-section">
+        <h2>Ramen</h2>
+        <div class="item">
+            <img src="images/REBI.png" alt="Ebi Furai">
+            <div class="info">
+                <h3>Ebi Furai</h3>
+                <p></p>
+                <strong>€ 18.00</strong>
+            </div>
+        </div>
+        <div class="item">
+            <img src="images/RCHICKEN.png" alt="Chicken">
+            <div class="info">
+                <h3>Chicken</h3>
+                <p></p>
+                <strong>€ 18.00</strong>
+            </div>
+        </div>
+        <div class="item">
+            <img src="images/RBEEF.png" alt="Beef">
+            <div class="info">
+                <h3>Beef</h3>
+                <p></p>
+                <strong>€ 18.00</strong>
+            </div>
+        </div>
+        <div class="item">
+            <img src="images/RUSU.png" alt="Ribeye">
+            <div class="info">
+                <h3>Ribeye</h3>
+                <p></p>
+                <strong>€ 18.00</strong>
+            </div>
+        </div>
+        <div class="item">
+            <img src="images/tonkotsu-ramen.png" alt="Cha siu (Geroosterd varkensvless)">
+            <div class="info">
+                <h3>Cha siu (Geroosterd varkensvless)</h3>
+                <p></p>
+                <strong>€ 18.00</strong>
+            </div>
+        </div>
+    </div>
+    <div class="menu-section">
+        <h2>Pokebowl</h2>
+        <div class="item">
+            <img src="images/zwp.png" alt="Zalm Bowl">
+            <div class="info">
+                <h3>Zalm Bowl</h3>
+                <p></p>
+                <strong>€ 15.00</strong>
+            </div>
+        </div>
+        <div class="item">
+            <img src="images/tup.png" alt="Tuna Bowl">
+            <div class="info">
+                <h3>Tuna Bowl</h3>
+                <p></p>
+                <strong>€ 15.00</strong>
+            </div>
+        </div>
+        <div class="item">
+            <img src="images/虾boel.png" alt="Ebi Fry Bowl">
+            <div class="info">
+                <h3>Ebi Fry Bowl</h3>
+                <p></p>
+                <strong>€ 15.50</strong>
+            </div>
+        </div>
+        <div class="item">
+            <img src="images/chicken-kar.jpg" alt="Chicken Karaage Bowl">
+            <div class="info">
+                <h3>Chicken Karaage Bowl</h3>
+                <p></p>
+                <strong>€ 15.50</strong>
+            </div>
+        </div>
+        <div class="item">
+            <img src="images/chicken-kar.jpg" alt="Spicy Chicken Bowl">
+            <div class="info">
+                <h3>Spicy Chicken Bowl</h3>
+                <p></p>
+                <strong>€ 15.50</strong>
+            </div>
+        </div>
+        <div class="item">
+            <img src="images/teriyaki-chicken-bowl.jpg" alt="Teriyaki Chicken Bowl">
+            <div class="info">
+                <h3>Teriyaki Chicken Bowl</h3>
+                <p></p>
+                <strong>€ 15.50</strong>
+            </div>
+        </div>
+        <div class="item">
+            <img src="images/nrp.png" alt="Teriyaki Beef Bowl">
+            <div class="info">
+                <h3>Teriyaki Beef Bowl</h3>
+                <p></p>
+                <strong>€ 15.50</strong>
+            </div>
+        </div>
+        <div class="item">
+            <img src="images/calibowl.png" alt="California Bowl">
+            <div class="info">
+                <h3>California Bowl</h3>
+                <p></p>
+                <strong>€ 14.00</strong>
+            </div>
+        </div>
+        <div class="item">
+            <img src="images/Unagi.jpg" alt="Unagi Bowl (Gerilde paling)">
+            <div class="info">
+                <h3>Unagi Bowl (Gerilde paling)</h3>
+                <p></p>
+                <strong>€ 16.00</strong>
+            </div>
+        </div>
+        <div class="item">
+            <img src="images/vega-bowl.jpg" alt="Vega Bowl (Vegetarisch)">
+            <div class="info">
+                <h3>Vega Bowl (Vegetarisch)</h3>
+                <p></p>
+                <strong>€ 13.00</strong>
+            </div>
+        </div>
+        <div class="item">
+            <img src="images/meatlover-bowl.jpg" alt="Meatlover Bowl">
+            <div class="info">
+                <h3>Meatlover Bowl</h3>
+                <p></p>
+                <strong>€ 17.00</strong>
+            </div>
+        </div>
+        <div class="item">
+            <img src="images/rainbowl.png" alt="Rainbowl">
+            <div class="info">
+                <h3>Rainbowl</h3>
+                <p></p>
+                <strong>€ 17.00</strong>
+            </div>
+        </div>
+        <div class="item">
+            <img src="images/spicy-tuna-bowl.jpg" alt="Spicy Tuna Bowl">
+            <div class="info">
+                <h3>Spicy Tuna Bowl</h3>
+                <p></p>
+                <strong>€ 15.50</strong>
+            </div>
+        </div>
+        <div class="item">
+            <img src="images/flamed-salmon-bowl.jpg" alt="Flamed Zalm Bowl">
+            <div class="info">
+                <h3>Flamed Zalm Bowl</h3>
+                <p></p>
+                <strong>€ 16.00</strong>
+            </div>
+        </div>
+        <div class="item">
+            <img src="images/flamed-tuna-bowl.png" alt="Flamed Tuna Bowl">
+            <div class="info">
+                <h3>Flamed Tuna Bowl</h3>
+                <p></p>
+                <strong>€ 16.00</strong>
+            </div>
+        </div>
+        <div class="item">
+            <img src="images/Xbowl.png" alt="X-Bowl">
+            <div class="info">
+                <h3>X-Bowl</h3>
+                <p></p>
+                <strong>€ 4</strong>
+            </div>
+        </div>
+    </div>
+    <div class="menu-section">
+        <h2>Teppanyaki Gebakken Rijst-Japanse stijl</h2>
+        <div class="item">
+            <img src="images/虾炒饭.png" alt="Garnaal">
+            <div class="info">
+                <h3>Garnaal</h3>
+                <p></p>
+                <strong>€ 18.00</strong>
+            </div>
+        </div>
+        <div class="item">
+            <img src="images/牛炒饭.png" alt="Rundvlees">
+            <div class="info">
+                <h3>Rundvlees</h3>
+                <p></p>
+                <strong>€ 18.00</strong>
+            </div>
+        </div>
+        <div class="item">
+            <img src="images/鸡炒饭.png" alt="Kip">
+            <div class="info">
+                <h3>Kip</h3>
+                <p></p>
+                <strong>€ 18.00</strong>
+            </div>
+        </div>
+        <div class="item">
+            <img src="images/叉烧炒饭.png" alt="Char Siu (BBQ-varkensvlees)">
+            <div class="info">
+                <h3>Char Siu (BBQ-varkensvlees)</h3>
+                <p></p>
+                <strong>€ 18.00</strong>
+            </div>
+        </div>
+    </div>
+    <div class="menu-section">
+        <h2>Omakase Sushi</h2>
+        <div class="item">
+            <img src="images/green-dragon-roll.png" alt="Salmon Roll Omakase">
+            <div class="info">
+                <h3>Salmon Roll Omakase</h3>
+                <p>9 st verrassing samengesteld</p>
+                <strong>€ 16.00</strong>
+            </div>
+        </div>
+        <div class="item">
+            <img src="images/angry-dragon.png" alt="Dragon Roll Omakase">
+            <div class="info">
+                <h3>Dragon Roll Omakase</h3>
+                <p>9 st verrassing samengesteld</p>
+                <strong>€ 16.00</strong>
+            </div>
+        </div>
+        <div class="item">
+            <img src="images/牛圈.png" alt="Beef Roll Omakase">
+            <div class="info">
+                <h3>Beef Roll Omakase</h3>
+                <p>9 st verrassing samengesteld</p>
+                <strong>€ 16.00</strong>
+            </div>
+        </div>
+        <div class="item">
+            <img src="images/几卷.png" alt="Chicken Roll Omakase">
+            <div class="info">
+                <h3>Chicken Roll Omakase</h3>
+                <p>9 st verrassing samengesteld</p>
+                <strong>€ 16.00</strong>
+            </div>
+        </div>
+        <div class="item">
+            <img src="images/NIG.png" alt="Nigiri Box Omakase">
+            <div class="info">
+                <h3>Nigiri Box Omakase</h3>
+                <p>5 stuks nigiri, verrassend samengesteld door de chef</p>
+                <strong>€ 10.00</strong>
+            </div>
+        </div>
+    </div>
+    <div class="menu-section">
+        <h2>Sashimi per 6 stuks</h2>
+        <div class="item">
+            <img src="images/ss.png" alt="Salmon sashimi">
+            <div class="info">
+                <h3>Salmon sashimi</h3>
+                <p></p>
+                <strong>€ 10.00</strong>
+            </div>
+        </div>
+        <div class="item">
+            <img src="images/fz.png" alt="Flamed salmon sashimi">
+            <div class="info">
+                <h3>Flamed salmon sashimi</h3>
+                <p></p>
+                <strong>€ 11.00</strong>
+            </div>
+        </div>
+        <div class="item">
+            <img src="images/st.png" alt="Tonijn sashimi">
+            <div class="info">
+                <h3>Tonijn sashimi</h3>
+                <p></p>
+                <strong>€ 10.00</strong>
+            </div>
+        </div>
+        <div class="item">
+            <img src="images/ft.png" alt="Flamed tonijn sashimi">
+            <div class="info">
+                <h3>Flamed tonijn sashimi</h3>
+                <p></p>
+                <strong>€ 11.00</strong>
+            </div>
+        </div>
+        <div class="item">
+            <img src="images/suy.png" alt="Beef sashimi">
+            <div class="info">
+                <h3>Beef sashimi</h3>
+                <p></p>
+                <strong>€ 12.00</strong>
+            </div>
+        </div>
+    </div>
+    <div class="menu-section">
+        <h2>Crispy rice sandwich</h2>
+        <div class="item">
+            <img src="images/Ebi.png" alt="Zalm crispy rice sandwich">
+            <div class="info">
+                <h3>Zalm crispy rice sandwich</h3>
+                <p></p>
+                <strong>€ 10.00</strong>
+            </div>
+        </div>
+        <div class="item">
+            <img src="images/Ebi.png" alt="Spicytuna crispy rice sandwich">
+            <div class="info">
+                <h3>Spicytuna crispy rice sandwich</h3>
+                <p></p>
+                <strong>€ 10.00</strong>
+            </div>
+        </div>
+        <div class="item">
+            <img src="images/Ebi.png" alt="Ebi crispy rice sandwich">
+            <div class="info">
+                <h3>Ebi crispy rice sandwich</h3>
+                <p></p>
+                <strong>€ 10.00</strong>
+            </div>
+        </div>
+        <div class="item">
+            <img src="images/beef-crispy.png" alt="Beef crispy rice sandwich">
+            <div class="info">
+                <h3>Beef crispy rice sandwich</h3>
+                <p></p>
+                <strong>€ 10.00</strong>
+            </div>
+        </div>
+        <div class="item">
+            <img src="images/california-crispy.png" alt="California crispy rice sandwich">
+            <div class="info">
+                <h3>California crispy rice sandwich</h3>
+                <p></p>
+                <strong>€ 10.00</strong>
+            </div>
+        </div>
+        <div class="item">
+            <img src="images/chicken-crispy.png" alt="Chicken crispy rice sandwich">
+            <div class="info">
+                <h3>Chicken crispy rice sandwich</h3>
+                <p></p>
+                <strong>€ 10.00</strong>
+            </div>
+        </div>
+    </div>
+    <div class="menu-section">
+        <h2>Snack</h2>
+        <div class="item">
+            <img src="images/karaage.png" alt="Karaage (Japanse gefrituurde kip)">
+            <div class="info">
+                <h3>Karaage (Japanse gefrituurde kip)</h3>
+                <p></p>
+                <strong>€ 6.50</strong>
+            </div>
+        </div>
+        <div class="item">
+            <img src="images/EB.jpg" alt="Ebi Fry – 4 st">
+            <div class="info">
+                <h3>Ebi Fry – 4 st</h3>
+                <p></p>
+                <strong>€ 6.50</strong>
+            </div>
+        </div>
+        <div class="item">
+            <img src="images/KRO.png" alt="Ebi kroket 4st">
+            <div class="info">
+                <h3>Ebi kroket 4st</h3>
+                <p></p>
+                <strong>€ 5.00</strong>
+            </div>
+        </div>
+        <div class="item">
+            <img src="images/karaage.png" alt="Spicy Crispy Chicken – 5 st">
+            <div class="info">
+                <h3>Spicy Crispy Chicken – 5 st</h3>
+                <p></p>
+                <strong>€ 6.50</strong>
+            </div>
+        </div>
+        <div class="item">
+            <img src="images/JZN.png" alt="Japans Zalm Nugget">
+            <div class="info">
+                <h3>Japans Zalm Nugget</h3>
+                <p></p>
+                <strong>€ 6.50</strong>
+            </div>
+        </div>
+        <div class="item">
+            <img src="images/LOM.png" alt="Mini Loempia – 6 st">
+            <div class="info">
+                <h3>Mini Loempia – 6 st</h3>
+                <p></p>
+                <strong>€ 3.50</strong>
+            </div>
+        </div>
+        <div class="item">
+            <img src="images/KIPL.png" alt="Chicken Loempia – 2 st">
+            <div class="info">
+                <h3>Chicken Loempia – 2 st</h3>
+                <p></p>
+                <strong>€ 5.00</strong>
+            </div>
+        </div>
+        <div class="item">
+            <img src="images/GYO.jpg" alt="Gyoza – 5 st">
+            <div class="info">
+                <h3>Gyoza – 5 st</h3>
+                <p></p>
+                <strong>€ 5.00</strong>
+            </div>
+        </div>
+        <div class="item">
+            <img src="images/INKT.jpg" alt="Inktvis Ringen – 5 st">
+            <div class="info">
+                <h3>Inktvis Ringen – 5 st</h3>
+                <p></p>
+                <strong>€ 5.00</strong>
+            </div>
+        </div>
+        <div class="item">
+            <img src="images/SEM.jpg" alt="Sesambal – 5 st">
+            <div class="info">
+                <h3>Sesambal – 5 st</h3>
+                <p></p>
+                <strong>€ 5.00</strong>
+            </div>
+        </div>
+        <div class="item">
+            <img src="images/YAK.jpg" alt="Yakitori – 4 st">
+            <div class="info">
+                <h3>Yakitori – 4 st</h3>
+                <p></p>
+                <strong>€ 6.00</strong>
+            </div>
+        </div>
+        <div class="item">
+            <img src="images/EDA.jpg" alt="Edamame">
+            <div class="info">
+                <h3>Edamame</h3>
+                <p></p>
+                <strong>€ 4.50</strong>
+            </div>
+        </div>
+        <div class="item">
+            <img src="images/KKK.jpg" alt="Kimchi Komkommer">
+            <div class="info">
+                <h3>Kimchi Komkommer</h3>
+                <p></p>
+                <strong>€ 4.50</strong>
+            </div>
+        </div>
+        <div class="item">
+            <img src="images/KIM.png" alt="Kimchi Kool">
+            <div class="info">
+                <h3>Kimchi Kool</h3>
+                <p></p>
+                <strong>€ 5.00</strong>
+            </div>
+        </div>
+        <div class="item">
+            <img src="images/ZEW.png" alt="Zeewiersalade – 100g">
+            <div class="info">
+                <h3>Zeewiersalade – 100g</h3>
+                <p></p>
+                <strong>€ 5.00</strong>
+            </div>
+        </div>
+    </div>
+    <div class="menu-section">
+        <h2>Dessert</h2>
+        <div class="item">
+            <img src="images/mochi-mango.png" alt="Mochi – Mango">
+            <div class="info">
+                <h3>Mochi – Mango</h3>
+                <p></p>
+                <strong>€ 4.00</strong>
+            </div>
+        </div>
+        <div class="item">
+            <img src="images/mochi-aardbei.png" alt="Mochi – Aardbei">
+            <div class="info">
+                <h3>Mochi – Aardbei</h3>
+                <p></p>
+                <strong>€ 4.00</strong>
+            </div>
+        </div>
+        <div class="item">
+            <img src="images/mochi-matcha.png" alt="Mochi – Matcha">
+            <div class="info">
+                <h3>Mochi – Matcha</h3>
+                <p></p>
+                <strong>€ 4.00</strong>
+            </div>
+        </div>
+        <div class="item">
+            <img src="images/mochi-pistachio.png" alt="Mochi – Pistachio">
+            <div class="info">
+                <h3>Mochi – Pistachio</h3>
+                <p></p>
+                <strong>€ 4.00</strong>
+            </div>
+        </div>
+    </div>
+    <div class="menu-section">
+        <h2>Drinks</h2>
+        <div class="item">
+            <img src="images/COLA.png" alt="Cola">
+            <div class="info">
+                <h3>Cola</h3>
+                <p></p>
+                <strong>€ 2.5</strong>
+            </div>
+        </div>
+        <div class="item">
+            <img src="images/COLAZERO.webp" alt="Cola Zero">
+            <div class="info">
+                <h3>Cola Zero</h3>
+                <p></p>
+                <strong>€ 2.50</strong>
+            </div>
+        </div>
+        <div class="item">
+            <img src="images/SPA_BLAUW.png" alt="Spa Blauw">
+            <div class="info">
+                <h3>Spa Blauw</h3>
+                <p></p>
+                <strong>€ 2.50</strong>
+            </div>
+        </div>
+        <div class="item">
+            <img src="images/SPA_ROOD.png" alt="Spa Rood">
+            <div class="info">
+                <h3>Spa Rood</h3>
+                <p></p>
+                <strong>€ 2.50</strong>
+            </div>
+        </div>
+        <div class="item">
+            <img src="images/RED_BULL.png" alt="Red Bull">
+            <div class="info">
+                <h3>Red Bull</h3>
+                <p></p>
+                <strong>€ 2.50</strong>
+            </div>
+        </div>
+        <div class="item">
+            <img src="images/HEINEKEN.png" alt="Heineken 330ml">
+            <div class="info">
+                <h3>Heineken 330ml</h3>
+                <p></p>
+                <strong>€ 3.00</strong>
+            </div>
+        </div>
+    </div>
+    <div class="menu-section">
+        <h2>Bubble Tea</h2>
+        <div class="item">
+            <img src="images/bubble-tea-main.jpg" alt="Bubble Tea">
+            <div class="info">
+                <h3>Bubble Tea</h3>
+                <p></p>
+                <strong>€ 5.00</strong>
+            </div>
+        </div>
+    </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- provide standalone `google-menu.html` with inline CSS for publishing on Google Business
- document availability of new file in README

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ae83952314833387709be5178e47e6