### PR TITLE
Add Apple-like admin orders page

### DIFF
--- a/admin_orders.css
+++ b/admin_orders.css
@@ -1,0 +1,172 @@
+:root {
+    color-scheme: light dark;
+    --radius-large: 18px;
+    --radius-small: 8px;
+    --shadow: 0 2px 8px rgba(0,0,0,0.08);
+    --bg: #ffffff;
+    --fg: #1c1c1e;
+    --bg-secondary: #f2f2f7;
+    --accent: #007aff;
+}
+@media (prefers-color-scheme: dark) {
+    :root {
+        --bg: #1c1c1e;
+        --fg: #f2f2f7;
+        --bg-secondary: #2c2c2e;
+        --shadow: 0 2px 8px rgba(0,0,0,0.6);
+    }
+}
+body {
+    margin: 0;
+    padding: 0;
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+    background: var(--bg);
+    color: var(--fg);
+    line-height: 1.5;
+}
+.toolbar {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 16px 32px;
+    gap: 16px;
+    background: var(--bg);
+    position: sticky;
+    top: 0;
+    z-index: 10;
+}
+.toolbar input,
+.toolbar select {
+    font-size: 14px;
+    padding: 8px 12px;
+    border-radius: var(--radius-small);
+    border: 1px solid rgba(0,0,0,0.1);
+    background: var(--bg-secondary);
+    color: var(--fg);
+}
+.btn {
+    padding: 8px 16px;
+    border-radius: var(--radius-large);
+    border: none;
+    cursor: pointer;
+    font-size: 14px;
+    transition: background 0.2s ease;
+}
+.btn.primary {
+    background: var(--accent);
+    color: #fff;
+}
+.btn.secondary {
+    background: var(--bg-secondary);
+    color: var(--fg);
+}
+.btn.icon {
+    background: transparent;
+    font-size: 24px;
+}
+.orders {
+    display: grid;
+    gap: 16px;
+    padding: 24px 32px 80px;
+}
+.orders.cards {
+    grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+}
+.order-card {
+    background: var(--bg-secondary);
+    border-radius: var(--radius-large);
+    padding: 16px;
+    box-shadow: var(--shadow);
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+.order-card h3 {
+    margin: 0;
+    font-weight: 600;
+}
+.order-card p {
+    margin: 0;
+    font-size: 14px;
+    color: var(--fg);
+    opacity: 0.7;
+}
+.order-card .details {
+    align-self: flex-start;
+}
+/* table view */
+.orders.table {
+    display: block;
+}
+.orders.table table {
+    width: 100%;
+    border-collapse: collapse;
+}
+.orders.table th,
+.orders.table td {
+    padding: 12px 8px;
+    text-align: left;
+    border-bottom: 1px solid rgba(0,0,0,0.1);
+}
+.drawer {
+    position: fixed;
+    top: 0;
+    right: 0;
+    width: 320px;
+    max-width: 80%;
+    height: 100%;
+    background: var(--bg);
+    box-shadow: -4px 0 12px rgba(0,0,0,0.1);
+    transform: translateX(100%);
+    transition: transform 0.25s ease-in-out;
+    display: flex;
+    flex-direction: column;
+}
+.drawer.visible {
+    transform: translateX(0);
+}
+.drawer-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 16px;
+    border-bottom: 1px solid rgba(0,0,0,0.1);
+}
+.drawer-body {
+    padding: 16px;
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+}
+.batch-bar {
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    background: var(--bg);
+    padding: 12px 32px;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    box-shadow: 0 -2px 8px rgba(0,0,0,0.1);
+}
+.banner {
+    padding: 12px 32px;
+    background: var(--bg-secondary);
+    text-align: center;
+}
+.toast {
+    position: fixed;
+    bottom: 24px;
+    left: 50%;
+    transform: translateX(-50%);
+    background: var(--fg);
+    color: var(--bg);
+    padding: 12px 24px;
+    border-radius: var(--radius-large);
+    box-shadow: var(--shadow);
+}
+.hidden {
+    display: none;
+}

--- a/admin_orders.html
+++ b/admin_orders.html
@@ -1,0 +1,82 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="light">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Admin Orders</title>
+    <link rel="stylesheet" href="admin_orders.css" />
+    <script defer src="admin_orders.js"></script>
+</head>
+<body>
+    <!-- Top Toolbar -->
+    <header class="toolbar">
+        <div class="toolbar-left">
+            <input type="search" placeholder="Search orders" class="search" />
+            <select class="filter">
+                <option>All Statuses</option>
+                <option>Pending</option>
+                <option>Completed</option>
+            </select>
+            <input type="date" class="date" />
+        </div>
+        <div class="toolbar-right">
+            <button id="toggleView" class="btn secondary">Table View</button>
+            <button class="btn primary">Export</button>
+        </div>
+    </header>
+
+    <!-- Inline Banner for status feedback -->
+    <div id="banner" class="banner hidden"></div>
+
+    <!-- Orders List -->
+    <main id="orders" class="orders cards">
+        <!-- sample order cards -->
+        <article class="order-card" data-id="1">
+            <input type="checkbox" class="select" />
+            <h3>Order #1001</h3>
+            <p>Table 5 · Pending</p>
+            <button class="details">Details</button>
+        </article>
+        <article class="order-card" data-id="2">
+            <input type="checkbox" class="select" />
+            <h3>Order #1002</h3>
+            <p>Table 2 · Completed</p>
+            <button class="details">Details</button>
+        </article>
+        <article class="order-card" data-id="3">
+            <input type="checkbox" class="select" />
+            <h3>Order #1003</h3>
+            <p>Takeaway · Pending</p>
+            <button class="details">Details</button>
+        </article>
+    </main>
+
+    <!-- Details Drawer -->
+    <aside id="drawer" class="drawer hidden">
+        <div class="drawer-header">
+            <h2>Order Details</h2>
+            <button id="closeDrawer" class="btn icon">&times;</button>
+        </div>
+        <div class="drawer-body">
+            <p id="orderInfo">Order content...</p>
+            <label>Status
+                <select id="status">
+                    <option>Pending</option>
+                    <option>Completed</option>
+                </select>
+            </label>
+            <button class="btn secondary" id="print">Print Receipt</button>
+        </div>
+    </aside>
+
+    <!-- Batch Action Bar -->
+    <div id="batchBar" class="batch-bar hidden">
+        <span id="selectedCount">0 selected</span>
+        <button class="btn secondary" id="batchExport">Export</button>
+        <button class="btn primary" id="batchMark">Mark Completed</button>
+    </div>
+
+    <!-- Toast Notification -->
+    <div id="toast" class="toast hidden"></div>
+</body>
+</html>

--- a/admin_orders.js
+++ b/admin_orders.js
@@ -1,0 +1,97 @@
+const orders = document.getElementById('orders');
+const toggleViewBtn = document.getElementById('toggleView');
+const drawer = document.getElementById('drawer');
+const closeDrawer = document.getElementById('closeDrawer');
+const orderInfo = document.getElementById('orderInfo');
+const batchBar = document.getElementById('batchBar');
+const selectedCount = document.getElementById('selectedCount');
+const toast = document.getElementById('toast');
+
+// toggle card/table view
+toggleViewBtn?.addEventListener('click', () => {
+    if (orders.classList.contains('cards')) {
+        renderTable();
+        orders.classList.remove('cards');
+        orders.classList.add('table');
+        toggleViewBtn.textContent = 'Card View';
+    } else {
+        renderCards();
+        orders.classList.remove('table');
+        orders.classList.add('cards');
+        toggleViewBtn.textContent = 'Table View';
+    }
+});
+
+function renderTable() {
+    const rows = [...document.querySelectorAll('.order-card')].map(card => {
+        const id = card.dataset.id;
+        const info = card.querySelector('p').textContent;
+        return `<tr><td><input type="checkbox" class="select" data-id="${id}"></td><td>${card.querySelector('h3').textContent}</td><td>${info}</td><td><button class="details" data-id="${id}">Details</button></td></tr>`;
+    }).join('');
+    orders.innerHTML = `<table><thead><tr><th></th><th>Order</th><th>Info</th><th></th></tr></thead><tbody>${rows}</tbody></table>`;
+}
+function renderCards() {
+    orders.innerHTML = `
+    <article class="order-card" data-id="1">
+        <input type="checkbox" class="select" />
+        <h3>Order #1001</h3>
+        <p>Table 5 · Pending</p>
+        <button class="details">Details</button>
+    </article>
+    <article class="order-card" data-id="2">
+        <input type="checkbox" class="select" />
+        <h3>Order #1002</h3>
+        <p>Table 2 · Completed</p>
+        <button class="details">Details</button>
+    </article>
+    <article class="order-card" data-id="3">
+        <input type="checkbox" class="select" />
+        <h3>Order #1003</h3>
+        <p>Takeaway · Pending</p>
+        <button class="details">Details</button>
+    </article>`;
+}
+
+// drawer logic
+orders.addEventListener('click', e => {
+    if (e.target.classList.contains('details')) {
+        const card = e.target.closest('[data-id]');
+        orderInfo.textContent = `Details for order ${card.dataset.id}`;
+        drawer.classList.add('visible');
+    }
+    if (e.target.classList.contains('select')) updateBatchBar();
+});
+
+document.body.addEventListener('change', e => {
+    if (e.target.classList.contains('select')) updateBatchBar();
+});
+
+closeDrawer?.addEventListener('click', () => {
+    drawer.classList.remove('visible');
+});
+
+// batch bar
+function updateBatchBar() {
+    const selected = document.querySelectorAll('.select:checked').length;
+    if (selected > 0) {
+        batchBar.classList.remove('hidden');
+        selectedCount.textContent = `${selected} selected`;
+    } else {
+        batchBar.classList.add('hidden');
+    }
+}
+
+// toast helper
+function showToast(message) {
+    toast.textContent = message;
+    toast.classList.remove('hidden');
+    setTimeout(() => toast.classList.add('hidden'), 2000);
+}
+
+document.getElementById('batchMark')?.addEventListener('click', () => {
+    showToast('Marked as completed');
+});
+
+document.getElementById('batchExport')?.addEventListener('click', () => {
+    showToast('Exported');
+});


### PR DESCRIPTION
## Summary
- add Apple-like `admin_orders.html` with toolbar, order list, details drawer, batch actions, toast
- include matching `admin_orders.css` for light/dark themes and Apple-inspired styling
- implement `admin_orders.js` for view toggling, selections, and notifications

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ae9a107f3c8333be7c6bf863a25eef