### PR TITLE
Generate PDF version of menu for Google My Business

### DIFF
--- a/generate_pdf.py
+++ b/generate_pdf.py
@@ -1,0 +1,73 @@
+import re
+from pathlib import Path
+
+# Read HTML file
+html = Path('google-menu.html').read_text(encoding='utf-8')
+
+# Regex to extract sections and items
+section_pattern = re.compile(r'<h2>(.*?)</h2>(.*?)</div>\s*</div>', re.DOTALL)
+item_pattern = re.compile(r'<h3>(.*?)</h3>\s*<p>.*?</p>\s*<strong>(.*?)</strong>', re.DOTALL)
+
+sections = []
+for sec_match in section_pattern.finditer(html):
+    section_name = re.sub(r'<.*?>', '', sec_match.group(1)).strip()
+    section_body = sec_match.group(2)
+    items = []
+    for item_match in item_pattern.finditer(section_body):
+        item_name = re.sub(r'<.*?>', '', item_match.group(1)).strip()
+        item_price = re.sub(r'<.*?>', '', item_match.group(2)).strip()
+
+        def normalize(text: str) -> str:
+            return (
+                text.replace('€', 'EUR').replace('–', '-').encode('latin-1', 'ignore').decode('latin-1')
+            )
+
+        items.append((normalize(item_name), normalize(item_price)))
+    sections.append((section_name, items))
+
+# Prepare text lines for PDF
+lines = ["Nova Asia - Digitale Menukaart"]
+for section_name, items in sections:
+    lines.append('')
+    lines.append(section_name)
+    for name, price in items:
+        lines.append(f"  - {name} {price}")
+
+# Function to escape parentheses in PDF text
+def pdf_escape(text: str) -> str:
+    return text.replace('\\', r'\\').replace('(', r'\(').replace(')', r'\)')
+
+# Build PDF content
+leading = 14
+content_lines = ["BT /F1 12 Tf {leading} TL 72 800 Td".format(leading=leading)]
+for i, line in enumerate(lines):
+    content_lines.append(f"({pdf_escape(line)}) Tj")
+    if i != len(lines) - 1:
+        content_lines.append('T*')
+content_lines.append('ET')
+content_stream = '\n'.join(content_lines)
+
+# PDF objects
+objects = []
+objects.append("1 0 obj << /Type /Catalog /Pages 2 0 R >> endobj\n")
+objects.append("2 0 obj << /Type /Pages /Kids [3 0 R] /Count 1 >> endobj\n")
+objects.append("3 0 obj << /Type /Page /Parent 2 0 R /MediaBox [0 0 595 842] /Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> >> endobj\n")
+objects.append(f"4 0 obj << /Length {len(content_stream.encode('latin-1'))} >> stream\n{content_stream}\nendstream endobj\n")
+objects.append("5 0 obj << /Type /Font /Subtype /Type1 /BaseFont /Helvetica >> endobj\n")
+
+# Assemble PDF
+pdf = "%PDF-1.4\n"
+offsets = [0]
+for obj in objects:
+    offsets.append(len(pdf.encode('latin-1')))
+    pdf += obj
+xref_pos = len(pdf.encode('latin-1'))
+
+pdf += f"xref\n0 {len(objects)+1}\n0000000000 65535 f \n"
+for off in offsets[1:]:
+    pdf += f"{off:010d} 00000 n \n"
+
+pdf += f"trailer << /Size {len(objects)+1} /Root 1 0 R >>\nstartxref\n{xref_pos}\n%%EOF"
+
+# Write PDF
+Path('google-menu.pdf').write_bytes(pdf.encode('latin-1'))

--- a/google-menu.pdf
+++ b/google-menu.pdf
@@ -1,0 +1,88 @@
+%PDF-1.4
+1 0 obj << /Type /Catalog /Pages 2 0 R >> endobj
+2 0 obj << /Type /Pages /Kids [3 0 R] /Count 1 >> endobj
+3 0 obj << /Type /Page /Parent 2 0 R /MediaBox [0 0 595 842] /Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> >> endobj
+4 0 obj << /Length 819 >> stream
+BT /F1 12 Tf 14 TL 72 800 Td
+(Nova Asia - Digitale Menukaart) Tj
+T*
+() Tj
+T*
+(Bento box) Tj
+T*
+(  - Japans Chicken Bento EUR 22.00) Tj
+T*
+() Tj
+T*
+(Ramen) Tj
+T*
+(  - Ebi Furai EUR 18.00) Tj
+T*
+() Tj
+T*
+(Pokebowl) Tj
+T*
+(  - Zalm Bowl EUR 15.00) Tj
+T*
+() Tj
+T*
+(Teppanyaki Gebakken Rijst-Japanse stijl) Tj
+T*
+(  - Garnaal EUR 18.00) Tj
+T*
+() Tj
+T*
+(Omakase Sushi) Tj
+T*
+(  - Salmon Roll Omakase EUR 16.00) Tj
+T*
+() Tj
+T*
+(Sashimi per 6 stuks) Tj
+T*
+(  - Salmon sashimi EUR 10.00) Tj
+T*
+() Tj
+T*
+(Crispy rice sandwich) Tj
+T*
+(  - Zalm crispy rice sandwich EUR 10.00) Tj
+T*
+() Tj
+T*
+(Snack) Tj
+T*
+(  - Karaage \(Japanse gefrituurde kip\) EUR 6.50) Tj
+T*
+() Tj
+T*
+(Dessert) Tj
+T*
+(  - Mochi - Mango EUR 4.00) Tj
+T*
+() Tj
+T*
+(Drinks) Tj
+T*
+(  - Cola EUR 2.5) Tj
+T*
+() Tj
+T*
+(Bubble Tea) Tj
+T*
+(  - Bubble Tea EUR 5.00) Tj
+ET
+endstream endobj
+5 0 obj << /Type /Font /Subtype /Type1 /BaseFont /Helvetica >> endobj
+xref
+0 6
+0000000000 65535 f 
+0000000009 00000 n 
+0000000058 00000 n 
+0000000115 00000 n 
+0000000241 00000 n 
+0000001111 00000 n 
+trailer << /Size 6 /Root 1 0 R >>
+startxref
+1181
+%%EOF


### PR DESCRIPTION
## Summary
- add `generate_pdf.py` script that parses `google-menu.html` and produces a PDF
- include generated `google-menu.pdf` ready for upload to Google My Business

## Testing
- `python3 generate_pdf.py`
- `ls -l google-menu.pdf`


------
https://chatgpt.com/codex/tasks/task_e_68b1fdfaffb483339b3e0fa5e7754777