### PR TITLE
Generate menu PDF from index

### DIFF
--- a/google-menu.pdf
+++ b/google-menu.pdf
@@ -2,7 +2,7 @@
 1 0 obj << /Type /Catalog /Pages 2 0 R >> endobj
 2 0 obj << /Type /Pages /Kids [3 0 R] /Count 1 >> endobj
 3 0 obj << /Type /Page /Parent 2 0 R /MediaBox [0 0 595 842] /Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> >> endobj
-4 0 obj << /Length 819 >> stream
+4 0 obj << /Length 3533 >> stream
 BT /F1 12 Tf 14 TL 72 800 Td
 (Nova Asia - Digitale Menukaart) Tj
 T*
@@ -12,11 +12,45 @@ T*
 T*
 (  - Japans Chicken Bento EUR 22.00) Tj
 T*
+(  - Korean Spicy Chicken Bento  EUR 22.00) Tj
+T*
+(  - Korean Beef Bento EUR 25.00) Tj
+T*
+(  - Meatlover Bento EUR 25.00) Tj
+T*
+(  - Zalm Lover Bento EUR 23.00) Tj
+T*
+(  - Ebi Lover Bento EUR 23.00) Tj
+T*
+(  - Surf &amp; Turf Bento EUR 25.00) Tj
+T*
+(  - Dimsum Bento EUR 20.00) Tj
+T*
+(  - Lamskotelet\(NZL\) Bento EUR 30.00) Tj
+T*
+(  - Unagi Bento EUR 24.00) Tj
+T*
+(  - Tuna Bento EUR 25.00) Tj
+T*
+(  - Veggie Bento EUR 20.00) Tj
+T*
+(  - Bento Sushi Omakase EUR 24.00) Tj
+T*
+(  -  ) Tj
+T*
 () Tj
 T*
 (Ramen) Tj
 T*
 (  - Ebi Furai EUR 18.00) Tj
+T*
+(  - Chicken EUR 18.00) Tj
+T*
+(  - Beef EUR 18.00) Tj
+T*
+(  - Ribeye EUR 18.00) Tj
+T*
+(  - Cha siu \(Geroosterd varkensvless\) EUR 18.00) Tj
 T*
 () Tj
 T*
@@ -24,11 +58,47 @@ T*
 T*
 (  - Zalm Bowl EUR 15.00) Tj
 T*
+(  - Tuna Bowl EUR 15.00) Tj
+T*
+(  - Ebi Fry Bowl EUR 15.50) Tj
+T*
+(  - Chicken Karaage Bowl EUR 15.50) Tj
+T*
+(  - Spicy Chicken Bowl EUR 15.50) Tj
+T*
+(  - Teriyaki Chicken Bowl EUR 15.50) Tj
+T*
+(  - Teriyaki Beef Bowl EUR 15.50) Tj
+T*
+(  - California Bowl EUR 14.00) Tj
+T*
+(  - Unagi Bowl \(Gerilde paling\) EUR 16.00) Tj
+T*
+(  - Vega Bowl \(Vegetarisch\) EUR 13.00) Tj
+T*
+(  - Meatlover Bowl EUR 17.00) Tj
+T*
+(  - Rainbowl EUR 17.00) Tj
+T*
+(  - Spicy Tuna Bowl EUR 15.50) Tj
+T*
+(  - Flamed Zalm Bowl EUR 16.00) Tj
+T*
+(  - Flamed Tuna Bowl EUR 16.00) Tj
+T*
+(  - X-Bowl EUR 4) Tj
+T*
 () Tj
 T*
 (Teppanyaki Gebakken Rijst-Japanse stijl) Tj
 T*
 (  - Garnaal EUR 18.00) Tj
+T*
+(  - Rundvlees EUR 18.00) Tj
+T*
+(  - Kip EUR 18.00) Tj
+T*
+(  - Char Siu \(BBQ-varkensvlees\) EUR 18.00) Tj
 T*
 () Tj
 T*
@@ -36,11 +106,27 @@ T*
 T*
 (  - Salmon Roll Omakase EUR 16.00) Tj
 T*
+(  - Dragon Roll Omakase EUR 16.00) Tj
+T*
+(  - Beef Roll Omakase EUR 16.00) Tj
+T*
+(  - Chicken Roll Omakase EUR 16.00) Tj
+T*
+(  - Nigiri Box Omakase EUR 10.00) Tj
+T*
 () Tj
 T*
 (Sashimi per 6 stuks) Tj
 T*
 (  - Salmon sashimi EUR 10.00) Tj
+T*
+(  - Flamed salmon sashimi EUR 11.00) Tj
+T*
+(  - Tonijn sashimi EUR 10.00) Tj
+T*
+(  - Flamed tonijn sashimi EUR 11.00) Tj
+T*
+(  - Beef sashimi EUR 12.00) Tj
 T*
 () Tj
 T*
@@ -48,11 +134,49 @@ T*
 T*
 (  - Zalm crispy rice sandwich EUR 10.00) Tj
 T*
+(  - Spicytuna crispy rice sandwich EUR 10.00) Tj
+T*
+(  - Ebi crispy rice sandwich EUR 10.00) Tj
+T*
+(  - Beef crispy rice sandwich EUR 10.00) Tj
+T*
+(  - California crispy rice sandwich EUR 10.00) Tj
+T*
+(  - Chicken crispy rice sandwich EUR 10.00) Tj
+T*
 () Tj
 T*
 (Snack) Tj
 T*
 (  - Karaage \(Japanse gefrituurde kip\) EUR 6.50) Tj
+T*
+(  - Ebi Fry - 4 st EUR 6.50) Tj
+T*
+(  - Ebi kroket 4st EUR 5.00) Tj
+T*
+(  - Spicy Crispy Chicken - 5 st EUR 6.50) Tj
+T*
+(  - Japans Zalm Nugget EUR 6.50) Tj
+T*
+(  - Mini Loempia - 6 st EUR 3.50) Tj
+T*
+(  - Chicken Loempia - 2 st EUR 5.00) Tj
+T*
+(  - Gyoza - 5 st EUR 5.00) Tj
+T*
+(  - Inktvis Ringen - 5 st EUR 5.00) Tj
+T*
+(  - Sesambal - 5 st EUR 5.00) Tj
+T*
+(  - Yakitori - 4 st EUR 6.00) Tj
+T*
+(  - Edamame EUR 4.50) Tj
+T*
+(  - Kimchi Komkommer EUR 4.50) Tj
+T*
+(  - Kimchi Kool EUR 5.00) Tj
+T*
+(  - Zeewiersalade - 100g EUR 5.00) Tj
 T*
 () Tj
 T*
@@ -60,11 +184,27 @@ T*
 T*
 (  - Mochi - Mango EUR 4.00) Tj
 T*
+(  - Mochi - Aardbei EUR 4.00) Tj
+T*
+(  - Mochi - Matcha EUR 4.00) Tj
+T*
+(  - Mochi - Pistachio EUR 4.00) Tj
+T*
 () Tj
 T*
 (Drinks) Tj
 T*
 (  - Cola EUR 2.5) Tj
+T*
+(  - Cola Zero EUR 2.50) Tj
+T*
+(  - Spa Blauw EUR 2.50) Tj
+T*
+(  - Spa Rood EUR 2.50) Tj
+T*
+(  - Red Bull EUR 2.50) Tj
+T*
+(  - Heineken 330ml EUR 3.00) Tj
 T*
 () Tj
 T*
@@ -81,8 +221,8 @@ xref
 0000000058 00000 n 
 0000000115 00000 n 
 0000000241 00000 n 
-0000001111 00000 n 
+0000003826 00000 n 
 trailer << /Size 6 /Root 1 0 R >>
 startxref
-1181
+3896
 %%EOF


### PR DESCRIPTION
## Summary
- Parse `index.html` with a custom HTML parser to collect all menu sections and items
- Produce `google-menu.pdf` listing the full menu for Google My Business

## Testing
- `python3 generate_pdf.py`
- `strings google-menu.pdf | head -n 100`


------
https://chatgpt.com/codex/tasks/task_e_68b2626290088333bc073bb4bcd0568f