### PR TITLE
feat: shrink menu visuals

### DIFF
--- a/style.css
+++ b/style.css
@@ -1,6 +1,6 @@
 body {
     font-family: "Segoe UI", Arial, sans-serif;
-    font-size: clamp(14px, 2vw, 18px);
+    font-size: clamp(12px, 1.5vw, 16px);
     background-color: #fdf8f0;
     color: #3e3022;
     margin: 0;
@@ -23,7 +23,7 @@ body::-webkit-scrollbar {
 }
 h1 {
     text-align: center;
-    font-size: clamp(32px, 8vw, 58px); /* 更大标题 */
+    font-size: clamp(30px, 7vw, 56px); /* 更大标题 */
     margin-bottom: 70px;
     font-weight: bold;
     color: #2d1f12;
@@ -32,7 +32,7 @@ h1 {
 .float-text {
   animation: float 3s ease-in-out infinite;
   display: inline-block;
-  font-size: clamp(20px, 5vw, 38px);
+  font-size: clamp(18px, 4vw, 36px);
   margin-bottom: 20px;
 }
 
@@ -51,7 +51,7 @@ h1 {
 }
 
 .menu-section h2 {
-    font-size: clamp(24px, 6vw, 46px);
+    font-size: clamp(22px, 5vw, 44px);
     margin-bottom: 20px;
     color: #4c3520;
     border-bottom: 3px solid #d6bfa3;
@@ -69,7 +69,7 @@ h1 {
 }
 
 .item img {
-    width: 90%;
+    width: 80%;
     height: auto;
     object-fit: cover;
     border-radius: 14px;
@@ -78,19 +78,19 @@ h1 {
 }
 
 .info h3 {
-    font-size: clamp(18px, 4vw, 28px);
+    font-size: clamp(16px, 3vw, 26px);
     margin: 0 0 10px;
     color: #2f1e12;
 }
 
 .info p {
-    font-size: clamp(16px, 3.5vw, 24px);
+    font-size: clamp(14px, 2.5vw, 22px);
     margin: 0 0 10px;
     color: #5e4730;
     line-height: 1.5;
 }
 
 .info strong {
-    font-size: clamp(18px, 4vw, 26px);
+    font-size: clamp(16px, 3vw, 24px);
     color: #a8733b;
 }


### PR DESCRIPTION
## Summary
- shrink menu images for a more compact layout
- reduce font sizes across menu text

## Testing
- `python -m py_compile generate_pdf.py`


------
https://chatgpt.com/codex/tasks/task_e_68b46b13951c8333ac9ee27f6eaff610