### PR TITLE
feat: convert menu to grid layout

### DIFF
--- a/google-menu.html
+++ b/google-menu.html
@@ -5,46 +5,60 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Menu - Nova Asia</title>
     <style>
-        body {
+        html, body {
+            margin: 0;
+            width: 100vw;
+            height: 100vh;
+            overflow: hidden;
             font-family: "Segoe UI", Arial, sans-serif;
             background-color: #fdf8f0;
             color: #3e3022;
-            margin: 0;
-            padding: 0 5%;
+        }
+
+        #menu-wrapper {
+            display: inline-block;
+            transform-origin: top left;
+            padding: 20px;
             box-sizing: border-box;
         }
 
         h1 {
             text-align: center;
-            margin-bottom: 40px;
+            margin: 0 0 40px;
         }
 
         .menu-section {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+            gap: 20px;
             margin-bottom: 40px;
         }
 
-        .menu-section h2 {
+        .menu-section > h2 {
+            grid-column: 1 / -1;
             border-bottom: 2px solid #d6bfa3;
             padding-bottom: 10px;
+            margin: 0 0 10px;
         }
 
         .item {
             display: flex;
+            flex-direction: column;
             align-items: center;
-            margin-bottom: 15px;
+            text-align: center;
         }
 
         .item img {
-            width: 80px;
-            height: 80px;
+            width: 100%;
+            height: 120px;
             object-fit: cover;
             border-radius: 14px;
-            margin-right: 15px;
+            margin-bottom: 10px;
         }
 
         .info h3 {
             margin: 0 0 5px;
-            font-size: 1.1em;
+            font-size: 1em;
             color: #2f1e12;
         }
 
@@ -55,10 +69,12 @@
 
         .info strong {
             color: #a8733b;
+            display: block;
         }
     </style>
 </head>
 <body>
+    <div id="menu-wrapper">
     <h1>Nova Asia - Digitale Menukaart</h1>
     <div class="menu-section">
         <h2>Bento box</h2>
@@ -738,6 +754,16 @@
             </div>
         </div>
     </div>
-    
+    </div>
+    <script>
+        function scaleMenu() {
+            const wrapper = document.getElementById('menu-wrapper');
+            wrapper.style.transform = 'scale(1)';
+            const scale = Math.min(window.innerWidth / wrapper.scrollWidth, window.innerHeight / wrapper.scrollHeight);
+            wrapper.style.transform = `scale(${scale})`;
+        }
+        window.addEventListener('load', scaleMenu);
+        window.addEventListener('resize', scaleMenu);
+    </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- render `google-menu.html` as grid-based static menu
- scale menu to fit viewport without scrollbars

## Testing
- `python -m py_compile generate_pdf.py`


------
https://chatgpt.com/codex/tasks/task_e_68b83c2ca4188333aa92904a4c444965